### PR TITLE
Subscript out of bounds error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: perlbrewr
 Title: Integrates Perlbrew With R, Specifically (knitr & rmarkdown)
-Version: 0.0.0.9000
+Version: 0.0.1.9000
 Authors@R: c(
   person("Roy", "Storey", email = "kiwiroy@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-1375-7136")))
 Description: The goal of perlbrewr is to assist the loading of a perlbrew 

--- a/R/knitr-shellwords.R
+++ b/R/knitr-shellwords.R
@@ -80,7 +80,9 @@ shellwords <- function(x) {
    )
   )"
   xo <- str_match_all(string = x, pattern = shellwords_re)
-
+  if (length(xo) == 0) {
+    return(character(0))
+  }
   for (i in seq_along(xo[[1]][,1])) {
     xo[[1]][i,7] <- NA
     if(!is.na(xo[[1]][i,6]) && xo[[1]][i,6] != "") {

--- a/tests/testthat/test-90-regression.R
+++ b/tests/testthat/test-90-regression.R
@@ -1,0 +1,6 @@
+context("regression tests")
+
+test_that("regression - handle NULL from knitr::opts_chunk$get('engine.opts')$perl ", {
+  words <- perlbrewr:::shellwords(x = NULL)
+  expect_equal(words, character(0))
+})


### PR DESCRIPTION
Passing `NULL` to `shellwords` - returned from `knits::opts_chunk$get("engine.opts")$perl` causes the following:
```
Error in xo[[1]] : subscript out of bounds
```

Checking with the empty string (`""`) and `NA` did not result in the error.